### PR TITLE
Follow-up: preserve line breaks around Chinese punctuation in Markdown post-processing

### DIFF
--- a/src/services/htmlToMarkdownConverter.js
+++ b/src/services/htmlToMarkdownConverter.js
@@ -515,8 +515,8 @@ class HtmlToMarkdownConverter {
      */
     _fixChinesePunctuation(markdown) {
         // 移除中文标点前后的不必要空格
-        return markdown.replace(/\s+([，。！？；：])/g, '$1')
-                      .replace(/([，。！？；：])\s+/g, '$1');
+        return markdown.replace(/[ \t]+([，。！？；：])/g, '$1')
+                      .replace(/([，。！？；：])[ \t]+/g, '$1');
     }
 
     /**

--- a/tests/htmlToMarkdownConverter.test.js
+++ b/tests/htmlToMarkdownConverter.test.js
@@ -452,5 +452,12 @@ describe('HtmlToMarkdownConverter', () => {
             // 表格前后应该有适当的空行
             expect(markdown).toMatch(/段落前\n\n.*表格.*\n\n段落后/s);
         });
+
+        test('should preserve line breaks after Chinese punctuation', () => {
+            const markdown = '第一段结束。\n\n第二段开始，内容继续。';
+            const fixed = converter._fixChinesePunctuation(markdown);
+
+            expect(fixed).toBe(markdown);
+        });
     });
 });


### PR DESCRIPTION
### Motivation
- The Markdown post-processing step could remove newline boundaries because the Chinese punctuation cleanup used `\s+`, which matches newlines and collapses paragraph breaks.
- The change aims to avoid losing expected line breaks in converted Markdown while still removing unwanted spaces/tabs around Chinese punctuation.

### Description
- Replace `\s+` with `[ \t]+` in `_fixChinesePunctuation` inside `src/services/htmlToMarkdownConverter.js` so only spaces and tabs are removed around `，。！？；：` without touching newlines. 
- Add a targeted regression test `should preserve line breaks after Chinese punctuation` to `tests/htmlToMarkdownConverter.test.js` that verifies line breaks are preserved.
- Modified and committed the two files `src/services/htmlToMarkdownConverter.js` and `tests/htmlToMarkdownConverter.test.js` as the minimal follow-up fix.

### Testing
- Ran the full `tests/htmlToMarkdownConverter.test.js` suite before the fix which showed several unrelated failures in the broader converter tests. 
- After the fix ran a focused test with `npm test -- tests/htmlToMarkdownConverter.test.js -t 'preserve line breaks after Chinese punctuation' --runInBand` and it passed. 
- The change is a small, localized regex and a regression test to prevent future regressions in newline handling around Chinese punctuation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bfa8b9b968832695cd8bc2a2e1ee5b)