### PR TITLE
Use configured wiki baseUrl in WikiPageService and add config tests

### DIFF
--- a/src/services/wikiPageService.js
+++ b/src/services/wikiPageService.js
@@ -7,6 +7,7 @@ const PageUrlHandler = require('./pageUrlHandler');
 const PageContentParser = require('./pageContentParser');
 const HtmlToMarkdownConverter = require('./htmlToMarkdownConverter');
 const { HttpClient } = require('../utils/httpClient');
+const config = require('../config');
 const { logger } = require('../utils/logger');
 
 class WikiPageService {
@@ -14,7 +15,7 @@ class WikiPageService {
         // 服务配置
         this.options = {
             // 基础URL
-            baseUrl: 'https://zh.minecraft.wiki',
+            baseUrl: config.wiki.baseUrl,
             
             // 缓存配置
             cacheOptions: {

--- a/tests/wikiPageService.config.test.js
+++ b/tests/wikiPageService.config.test.js
@@ -1,0 +1,52 @@
+/**
+ * WikiPageService configuration tests
+ */
+
+const mockConfig = (baseUrl) => {
+    jest.doMock('../src/config', () => {
+        const actualConfig = jest.requireActual('../src/config');
+
+        return {
+            ...actualConfig,
+            wiki: {
+                ...actualConfig.wiki,
+                baseUrl
+            }
+        };
+    });
+};
+
+describe('WikiPageService configuration', () => {
+    afterEach(() => {
+        jest.dontMock('../src/config');
+        jest.resetModules();
+    });
+
+    test('should use configured wiki base URL by default', () => {
+        jest.resetModules();
+        mockConfig('https://configured.example/wiki/');
+
+        const WikiPageService = require('../src/services/wikiPageService');
+        const service = new WikiPageService({
+            cacheOptions: { enabled: false }
+        });
+
+        expect(service.options.baseUrl).toBe('https://configured.example/wiki/');
+        expect(service.urlHandler.baseUrl).toBe('https://configured.example/wiki');
+        expect(service.urlHandler.buildPageUrl('钻石')).toBe('https://configured.example/wiki/w/%E9%92%BB%E7%9F%B3');
+    });
+
+    test('should allow explicit base URL options to override configuration', () => {
+        jest.resetModules();
+        mockConfig('https://configured.example');
+
+        const WikiPageService = require('../src/services/wikiPageService');
+        const service = new WikiPageService({
+            baseUrl: 'https://override.example',
+            cacheOptions: { enabled: false }
+        });
+
+        expect(service.options.baseUrl).toBe('https://override.example');
+        expect(service.urlHandler.baseUrl).toBe('https://override.example');
+    });
+});


### PR DESCRIPTION
### Motivation
- Remove the hardcoded wiki base URL in `WikiPageService` so the service uses the application's central configuration and respects environment overrides. 

### Description
- Import the shared configuration and replace the hardcoded `baseUrl` with `config.wiki.baseUrl` as the service default in `src/services/wikiPageService.js`.
- Preserve existing behavior where an explicit `baseUrl` passed to the constructor still overrides the configured default.
- Add a focused test file `tests/wikiPageService.config.test.js` that `jest.doMock`s the app config to assert that the configured default is used and that explicit constructor options take precedence.

### Testing
- Ran the focused test: `npm test -- --runTestsByPath tests/wikiPageService.config.test.js`, and it passed.
- Ran the full test suite with `npm test -- --runInBand`; the new tests pass but the overall suite reported unrelated failures (existing integration and network tests and some parsing/search builder tests) which are outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc798c87508327ad05011d0eaddab9)