### PR TITLE
fix: URL-encode pageName slash, remove markdown from MCP format

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ claude mcp add --transport http zh-minecraft-wiki http://localhost:3001/mcp
 | 工具 | 用途 |
 |---|---|
 | `search_wiki(q, limit, namespaces)` | 搜索 Wiki 页面，`namespaces` 可限定数字ID |
-| `get_page(pageName, format, useCache, includeMetadata)` | 获取页面，`format`：`wikitext`（默认）、`markdown`、`html` |
+| `get_page(pageName, format, useCache, includeMetadata)` | 获取页面，`format`：`wikitext`（默认，最完整）、`html` |
 | `check_page_exists(pageName)` | 检查页面是否存在 |
 | `check_health()` | 检查 API 服务健康状态 |
 | `list_namespaces()` | 获取命名空间映射表（数字ID → 名称） |

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -80,7 +80,7 @@ async def get_page(
         params = {"format": format, "useCache": str(useCache).lower()}
         async with httpx.AsyncClient(timeout=30, trust_env=False) as client:
             resp = await client.get(
-                f"{API_BASE}/api/page/{quote(pageName)}",
+                f"{API_BASE}/api/page/{quote(pageName, safe='')}",
                 params=params,
             )
             data = resp.json()
@@ -124,7 +124,7 @@ async def check_page_exists(
     """检查页面是否存在。"""
     try:
         async with httpx.AsyncClient(timeout=30, trust_env=False) as client:
-            resp = await client.get(f"{API_BASE}/api/page/{pageName}/exists")
+            resp = await client.get(f"{API_BASE}/api/page/{quote(pageName, safe='')}/exists")
             data = resp.json()
     except Exception as e:
         return f"检查失败: API 服务不可用 ({e})"

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -56,7 +56,7 @@ async def get_page(
         str,
         Field(
             default="wikitext",
-            description="输出格式：wikitext（默认，最完整，推荐）、markdown、html（仅在 wikitext 模板无法理解时使用）",
+description="**非必要不要传此参数，默认 wikitext 就是最好的。** wikitext 完全保留模板语义；html 仅在 wikitext 模板确实无法理解时使用",
         ),
     ] = "wikitext",
     useCache: Annotated[bool, Field(description="是否使用缓存，默认 true")] = True,
@@ -64,15 +64,14 @@ async def get_page(
 ) -> str:
     """获取 Minecraft 中文 Wiki 页面的内容。
 
-    根据页面名称获取 Wiki 页面的完整内容，支持三种格式。
+    根据页面名称获取 Wiki 页面的完整内容。
 
-    格式选择建议：
-    - wikitext（默认，推荐）：最完整的格式，包含 Wiki 原始标记语言。
-      所有信息框、历史表格、配方等模板数据均以 {{Template}} 形式完整保留。
-      绝大多数情况下应优先使用 wikitext。
-    - markdown：HTML 转 Markdown，适合易读场景，部分复杂模板可能丢失。
-    - html：清洗后的正文 HTML。仅在 wikitext 中某个模板无法理解时使用。非必要不用。"""
-    valid_formats = ("wikitext", "markdown", "html")
+    格式选择：
+    - wikitext（默认）：Wiki 原始标记语言，{{Template}} 完整保留，信息最全。
+    - html：清洗后的正文 HTML。仅当 wikitext 中某个模板语法确实无法理解时才使用。
+
+    wikitext 中遇到不认识的 {{Template}} 时，可用 search_wiki 传 namespaces=[10] 去模板命名空间搜索该模板的文档。"""
+    valid_formats = ("wikitext", "html")
     if format not in valid_formats:
         return f"无效的 format: {format}，可选值: {', '.join(valid_formats)}"
 
@@ -98,9 +97,7 @@ async def get_page(
 
     if format == "wikitext":
         content = page["content"]["wikitext"]
-    elif format == "markdown":
-        content = page["content"]["markdown"]
-    elif format == "html":
+    else:
         content = page["content"]["html"]
 
     info_lines = [f"# {page['pageName']}", f"URL: {page['url']}"]


### PR DESCRIPTION
- `get_page` 和 `check_page_exists` 的 pageName 中 `/` 被正确编码
- `get_page` 移除 markdown 格式，只保留 wikitext（默认）和 html
- format 参数描述强调：非必要不要传，默认 wikitext 就是最好的
- 新增提示：wikitext 遇到不认识的模板时，去 Template 命名空间搜索

## Test plan
- [x] get_page("命令/function") 正常返回
- [x] check_page_exists("命令/function") 正常返回
- [x] get_page(format="markdown") 被拒绝并提示可选值